### PR TITLE
reelase 1.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # TJLabsCommon-sdk-android
+
+Android Common SDK for RFD/UVD generation and simulation playback.
+
+## Requirements
+
+### Consumer App
+- Kotlin
+- Android API 26+
+
+### SDK Build/Release (this repository)
+- JDK 17 (AGP 8.6.0)
+- Gradle 8.7 (wrapper)
+
+## Installation (JitPack)
+
+### 1) Add JitPack repository
+
+`settings.gradle.kts`
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven(url = "https://jitpack.io")
+    }
+}
+```
+
+### 2) Add dependency
+
+`app/build.gradle.kts`
+
+```kotlin
+dependencies {
+    implementation("com.github.tjlabs:TJLabsCommon-sdk-android:<tag>")
+}
+```
+
+- Replace `<tag>` with your release tag.
+- This repository is multi-module, but consumers should use the `:sdk` artifact only.
+
+## Required Permissions
+
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+```

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk17
+
+install:
+  - ./gradlew :sdk:publishToMavenLocal -x test --stacktrace --no-daemon

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -39,6 +39,12 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {
@@ -53,7 +59,7 @@ afterEvaluate {
         publications {
             create<MavenPublication>("release") {
                 from(components["release"])
-                groupId = "com.tjlabs"
+                groupId = "com.github.tjlabs"
                 artifactId = "TJLabsCommon-sdk-android"
                 version = "$versionMajor.$versionMinor.$versionPatch"
             }

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,6 @@ dependencyResolutionManagement {
 
     repositories {
         mavenLocal()
-        maven { url = uri("/Users/yuchangsoo/local-maven-repo") }
         google()
         mavenCentral()
         maven(url = "https://jitpack.io")


### PR DESCRIPTION
## 개요
JitPack 배포 안정성을 높이기 위해 빌드/출판 경로를 `:sdk` 중심으로 고정하고, 루트 빌드 실패 가능 요소 및 문서 누락을 정리했습니다.

## 변경 배경
기존 상태에서 다음 리스크가 있었습니다.

- `jitpack.yml` 부재로 JitPack 기본 루트 빌드 경로 의존
- `settings.gradle.kts`에 로컬 절대경로 저장소 포함 (`/Users/.../local-maven-repo`)
- 루트 `clean build` 시 `app:lintDebug` 실패 가능
- README에 JitPack 설치/좌표/요구사항 가이드 부재

## 주요 변경 사항

### 1) JitPack 빌드 경로 고정
- `jitpack.yml` 신규 추가
- JDK 17 명시
- install 단계에서 라이브러리 모듈만 publish 실행

```yml
jdk:
  - openjdk17

install:
  - ./gradlew :sdk:publishToMavenLocal -x test --stacktrace --no-daemon
