### PR TITLE
[TJ-164] simplify BLE permissions and add optional sdk logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Android Common SDK for RFD/UVD generation and simulation playback.
 - Android API 26+
 
 ### SDK Build/Release (this repository)
-- JDK 17 (AGP 8.6.0)
+- JDK 17
+- AGP 8+ (current: 8.6.0)
 - Gradle 8.7 (wrapper)
 
 ## Installation (JitPack)
@@ -41,13 +42,53 @@ dependencies {
 - Replace `<tag>` with your release tag.
 - This repository is multi-module, but consumers should use the `:sdk` artifact only.
 
+## CI/CD Automation
+
+### PR Validation Workflow
+- File: `.github/workflows/pr-validate.yml`
+- Triggers:
+  - `pull_request` to `main`, `release/*`
+  - `workflow_dispatch`
+- Validation steps:
+  - JDK 17 setup
+  - `:sdk:testDebugUnitTest`
+  - `:sdk:testReleaseUnitTest`
+  - `:sdk:publishToMavenLocal -x test`
+- Any failure makes the workflow fail (usable as required status check for merge gate).
+
+### Release Automation Workflow
+- File: `.github/workflows/release-jitpack.yml`
+- Triggers:
+  - `push` to `release/*`
+  - `workflow_dispatch` with optional `release_version`
+- Automation steps:
+  - Resolve release version (`workflow input` first, fallback from `release/x.y.z` branch)
+  - Validate version format (`x.y.z`)
+  - Verify module version in `sdk/build.gradle.kts` matches release version
+  - Run SDK unit tests + publish check
+  - Create/push Git tag (`x.y.z`) if missing
+  - Warm up JitPack build endpoint and upload build-log artifacts
+
+### Exclusions
+- Live API smoke tests are intentionally excluded from automated workflows.
+
 ## Required Permissions
 
 ```xml
 <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
 <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+```
+
+## Optional SDK Logs
+
+SDK internal logs are disabled by default. You can enable or disable them at runtime:
+
+```kotlin
+import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsCommonLog
+
+TJLabsCommonLog.setEnabled(true)  // enable
+TJLabsCommonLog.setEnabled(false) // disable
 ```

--- a/app/src/main/java/com/tjlabs/tjlabscommon_sample/MainActivity.kt
+++ b/app/src/main/java/com/tjlabs/tjlabscommon_sample/MainActivity.kt
@@ -26,7 +26,6 @@ class MainActivity : AppCompatActivity() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             arrayOf(
                 Manifest.permission.BLUETOOTH_SCAN,
-                Manifest.permission.BLUETOOTH_CONNECT,
                 Manifest.permission.ACCESS_FINE_LOCATION
             )
         } else {

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 val versionMajor = 1
 val versionMinor = 0
-val versionPatch = 16
+val versionPatch = 17
 
 android {
     namespace = "com.tjlabs.tjlabscommon_sdk_android"

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 
 </manifest>

--- a/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/rfd/RFDGenerator.kt
+++ b/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/rfd/RFDGenerator.kt
@@ -8,13 +8,13 @@ import android.os.Handler
 import android.os.Looper
 import android.os.ParcelUuid
 import android.os.SystemClock
-import android.util.Log
 import com.tjlabs.tjlabscommon_sdk_android.simulation.JupiterDataFunctions
 import com.tjlabs.tjlabscommon_sdk_android.simulation.JupiterDataFunctions.bleMutableList
 import com.tjlabs.tjlabscommon_sdk_android.simulation.JupiterDataFunctions.bleSimulationIndex
 import com.tjlabs.tjlabscommon_sdk_android.simulation.JupiterDataFunctions.loadRfdJsonData
 import com.tjlabs.tjlabscommon_sdk_android.simulation.JupiterDataFunctions.parseStringToMap
 import com.tjlabs.tjlabscommon_sdk_android.simulation.JupiterDataFunctions.saveRfdResultAsJson
+import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsCommonLog
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions
 import java.util.Timer
 import java.util.TimerTask
@@ -211,7 +211,6 @@ class RFDGenerator(private val application: Application, val userId : String = "
             timer.schedule(object : TimerTask() {
                 override fun run() {
                     if (bleSimulationIndex < bleMutableList.size) {
-                        Log.d("CheckFileData", "rfd change")
                         val index = bleSimulationIndex % bleMutableList.size
                         val element = bleMutableList[index]
                         val averageBleMap = parseStringToMap(element)
@@ -323,7 +322,6 @@ class RFDGenerator(private val application: Application, val userId : String = "
         tjLabsBluetoothManager.stopScan()
         // TODO() stopScan 리턴 활용하기
         bleScanInfoSet.clear()
-        Log.d("CheckBLERestart", "stop scan")
     }
 
     fun checkRfdException(callback: RFDCallback){

--- a/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/rfd/TJLabsBluetoothFunctions.kt
+++ b/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/rfd/TJLabsBluetoothFunctions.kt
@@ -1,6 +1,6 @@
 package com.tjlabs.tjlabscommon_sdk_android.rfd
 
-import android.util.Log
+import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsCommonLog
 
 internal object TJLabsBluetoothFunctions {
     fun removeBleScanInfoSetOlderThan(bleScanInfoSet: MutableSet<BLEScanInfo>, elapsedRealtimeNano: Long) : MutableSet<BLEScanInfo> {
@@ -24,7 +24,7 @@ internal object TJLabsBluetoothFunctions {
                 val count = infoList.size
                 val total = infoList.sumOf { it.rssi }
                 val average = if (count > 0) total.toFloat() / count else 0f
-                Log.d(
+                TJLabsCommonLog.d(
                     "TJLabsBluetoothFunctions",
                     "BLE ID: $id | count: $count | total RSSI: $total | average RSSI: $average | rssi list : ${infoList.map { it.rssi }}"
                 )
@@ -35,7 +35,7 @@ internal object TJLabsBluetoothFunctions {
             averageMap = rssiClassMap.map { it.key to (it.value.getAverage()).toFloat() }.toMap()
 
         } catch (e: Exception) {
-            Log.e("TJLabsBluetoothFunctions", "error, average BLE Scan Info", e)
+            TJLabsCommonLog.e("TJLabsBluetoothFunctions", "error, average BLE Scan Info", e)
         }
 
         return averageMap

--- a/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/rfd/TJLabsBluetoothManager.kt
+++ b/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/rfd/TJLabsBluetoothManager.kt
@@ -15,7 +15,6 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
-import android.util.Log
 import androidx.core.app.ActivityCompat
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions
 import java.util.Collections
@@ -62,8 +61,7 @@ internal class TJLabsBluetoothManager(private val context: Context) {
     fun checkPermissions() : Pair<Boolean, String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             val hasBlePermissions =
-                ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED &&
-                    ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
+                ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED
 
             val hasFineLocation =
                 ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
@@ -72,7 +70,7 @@ internal class TJLabsBluetoothManager(private val context: Context) {
             val hasLocationPermission = hasFineLocation || hasCoarseLocation
 
             if (!hasBlePermissions) {
-                Pair(false, "Required BLE permissions(BLUETOOTH_SCAN/CONNECT) are not granted.")
+                Pair(false, "Required BLE permission(BLUETOOTH_SCAN) is not granted.")
             } else if (!hasLocationPermission) {
                 Pair(false, "Location permission(ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION) is required.")
             } else {

--- a/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/utils/TJLabsCommonLog.kt
+++ b/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/utils/TJLabsCommonLog.kt
@@ -1,0 +1,35 @@
+package com.tjlabs.tjlabscommon_sdk_android.utils
+
+import android.util.Log
+
+object TJLabsCommonLog {
+    @Volatile
+    private var isEnabled: Boolean = false
+
+    fun setEnabled(enabled: Boolean) {
+        isEnabled = enabled
+    }
+
+    fun isLogEnabled(): Boolean = isEnabled
+
+    fun d(tag: String, message: String) {
+        if (isEnabled) Log.d(tag, message)
+    }
+
+    fun i(tag: String, message: String) {
+        if (isEnabled) Log.i(tag, message)
+    }
+
+    fun w(tag: String, message: String) {
+        if (isEnabled) Log.w(tag, message)
+    }
+
+    fun e(tag: String, message: String, throwable: Throwable? = null) {
+        if (!isEnabled) return
+        if (throwable == null) {
+            Log.e(tag, message)
+        } else {
+            Log.e(tag, message, throwable)
+        }
+    }
+}

--- a/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/uvd/TJLabsAttitudeEstimator.kt
+++ b/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/uvd/TJLabsAttitudeEstimator.kt
@@ -1,6 +1,4 @@
 package com.tjlabs.tjlabscommon_sdk_android.uvd
-
-import android.util.Log
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions.calAngleOfRotation
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions.calAttEMA
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions.calAttitudeUsingGameVector

--- a/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/uvd/dr/TJLabsDRDistanceEstimator.kt
+++ b/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/uvd/dr/TJLabsDRDistanceEstimator.kt
@@ -1,6 +1,6 @@
 package com.tjlabs.tjlabscommon_sdk_android.uvd.dr
 
-import android.util.Log
+import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsCommonLog
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions.calPitchUsingAcc
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions.calRMS
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions.calRollUsingAcc
@@ -229,7 +229,7 @@ internal class TJLabsDRDistanceEstimator {
 
         count ++
         if (count > 10) {
-            Log.d("CheckVelocity", "final vel : ${finalUnitResult.velocity} // raw velocity smooth : $velocitySmoothing // scale : ${velocityScale} // ent scale : $entranceVelocityScale //  turn scale : $turnScale // rflow : $rflowScale // isSufficientRfdBuffer : $isSufficientRfdBuffer // drState : $drState")
+            TJLabsCommonLog.d("CheckVelocity", "final vel : ${finalUnitResult.velocity} // raw velocity smooth : $velocitySmoothing // scale : ${velocityScale} // ent scale : $entranceVelocityScale //  turn scale : $turnScale // rflow : $rflowScale // isSufficientRfdBuffer : $isSufficientRfdBuffer // drState : $drState")
             count = 0
         }
 

--- a/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/uvd/pdr/TJLabsPDRDistanceEstimator.kt
+++ b/sdk/src/main/java/com/tjlabs/tjlabscommon_sdk_android/uvd/pdr/TJLabsPDRDistanceEstimator.kt
@@ -1,6 +1,6 @@
 package com.tjlabs.tjlabscommon_sdk_android.uvd.pdr
 
-import android.util.Log
+import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsCommonLog
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions.exponentialMovingAverage
 import com.tjlabs.tjlabscommon_sdk_android.utils.TJLabsUtilFunctions.l2Normalize
 import com.tjlabs.tjlabscommon_sdk_android.uvd.SensorData
@@ -186,7 +186,6 @@ internal class TJLabsPDRDistanceEstimator
     }
 
     private fun checkNormalStep(normalStepCount: Int, normalStepCountSet: Int = NORMAL_STEP_COUNT_SET): Boolean {
-        Log.d("CheckNormalStep", "normalStepCount : $normalStepCount // normalStepCountSet : $normalStepCountSet")
         return normalStepCount >= normalStepCountSet
     }
 
@@ -197,5 +196,4 @@ internal class TJLabsPDRDistanceEstimator
     }
 
 }
-
 


### PR DESCRIPTION
## 작업 정보
- Task: TJ-164
- Branch: release/1.0.17
- Commit: dce193e

## 변경 목적
- 불필요한 BLE 권한 요청을 제거하고,
- SDK 로그를 필요 시에만 보이도록 제어 가능하게 개선

## 주요 변경 사항

1. 권한 정리
- SDK manifest에서 `BLUETOOTH_CONNECT` 제거
- API 31+ 권한 체크에서 `BLUETOOTH_CONNECT` 강제 체크 제거
- 샘플 앱 런타임 권한 요청에서 `BLUETOOTH_CONNECT` 제거

2. 로그 선택 제어 추가
- `TJLabsCommonLog` 유틸 추가
- SDK 내부 `Log.d/e` 사용 지점을 `TJLabsCommonLog`로 치환
- 기본값은 비활성(`false`), 필요 시 `setEnabled(true)`로 활성화 가능

3. 문서 업데이트
- README 권한 예시에서 `BLUETOOTH_CONNECT` 제거
- README에 Optional SDK Logs 섹션 추가 (`TJLabsCommonLog.setEnabled(...)` 사용법)

4. 버전
- SDK patch 버전 `1.0.17` 반영

## 검증

실행 명령:
- `./gradlew :sdk:assembleDebug :app:assembleDebug --stacktrace --no-daemon`
- `./gradlew :sdk:publishToMavenLocal -x test --stacktrace --no-daemon`

결과:
- 모두 `BUILD SUCCESSFUL`

## 영향 범위
- BLE 스캔 기반 동작 기준 권한 요청 단순화
- 운영 시 불필요한 디버그 로그 노출 최소화
- 디버깅 필요 시 로그를 런타임에서 선택적으로 활성화 가능

## 체크리스트
- [x] 불필요 권한 요청 제거
- [x] SDK 로그 온/오프 제어 추가
- [x] README 반영
- [x] 로컬 빌드/배포 검증
