### PR TITLE
feat: Wards bundle comparison + file replay

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,7 @@ android {
 dependencies {
     implementation(project(":sdk"))
     implementation("com.github.tjlabs:TJLabsAuth-sdk-android:1.0.26")
+    implementation("com.github.tjlabs:TJLabsResource-sdk-android:1.1.7")
 
     implementation(libs.androidx.core.ktx.v131)
     implementation(libs.androidx.appcompat)

--- a/app/src/main/java/com/tjlabs/tjlabscommon_sample/MainActivity.kt
+++ b/app/src/main/java/com/tjlabs/tjlabscommon_sample/MainActivity.kt
@@ -151,7 +151,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun openWards() {
-        startActivity(Intent(this, ScannedWardsActivity::class.java))
+        val intent = Intent(this, ScannedWardsActivity::class.java)
+        selectedSector?.let {
+            intent.putExtra(ScannedWardsActivity.EXTRA_SECTOR_ID, it.id)
+            intent.putExtra(ScannedWardsActivity.EXTRA_SECTOR_DISPLAY, it.display)
+        }
+        startActivity(intent)
     }
 
     private fun applyRunningState(running: Boolean) {

--- a/app/src/main/java/com/tjlabs/tjlabscommon_sample/wards/BundleService.kt
+++ b/app/src/main/java/com/tjlabs/tjlabscommon_sample/wards/BundleService.kt
@@ -1,0 +1,56 @@
+package com.tjlabs.tjlabscommon_sample.wards
+
+import android.app.Application
+import android.util.Log
+import com.tjlabs.tjlabsresource_sdk_android.ResourceRegion
+import com.tjlabs.tjlabsresource_sdk_android.ServerProvider
+import com.tjlabs.tjlabsresource_sdk_android.TJLabsResourceManager
+
+data class BundleWardMap(
+    val sectorId: Int,
+    val nameToLevelLabel: Map<String, String>,
+) {
+    val allWardNames: Set<String> get() = nameToLevelLabel.keys
+    val levelCount: Int get() = nameToLevelLabel.values.toSet().size
+}
+
+object BundleService {
+
+    private const val TAG = "BundleService"
+
+    fun load(
+        application: Application,
+        sectorId: Int,
+        provider: String = ServerProvider.GCP.value,
+        region: String = ResourceRegion.KOREA.value,
+        onDone: (Result<BundleWardMap>) -> Unit,
+    ) {
+        val manager = TJLabsResourceManager()
+        Log.d(TAG, "loadResource sector=$sectorId provider=$provider region=$region")
+        manager.loadResource(application, provider, region, sectorId) { success ->
+            if (!success) {
+                onDone(Result.failure(IllegalStateException("loadResource failed")))
+                return@loadResource
+            }
+            val raw = manager.getLevelWardsData()
+            val map = LinkedHashMap<String, String>()
+            for ((key, wardNames) in raw) {
+                val label = levelLabelFromKey(key, sectorId)
+                for (name in wardNames) {
+                    map.putIfAbsent(name, label)
+                }
+            }
+            Log.d(TAG, "loadResource done levels=${raw.size} wards=${map.size}")
+            onDone(Result.success(BundleWardMap(sectorId, map)))
+        }
+    }
+
+    // Key format from Resource SDK: "{sectorId}_{buildingName}_{levelName}" → return only level.
+    private fun levelLabelFromKey(key: String, sectorId: Int): String {
+        val prefix = "${sectorId}_"
+        val trimmed = if (key.startsWith(prefix)) key.substring(prefix.length) else key
+        val cut = trimmed.indexOf('_')
+        if (cut <= 0 || cut == trimmed.length - 1) return trimmed
+        return trimmed.substring(cut + 1)
+    }
+}

--- a/app/src/main/java/com/tjlabs/tjlabscommon_sample/wards/ScannedWardTracker.kt
+++ b/app/src/main/java/com/tjlabs/tjlabscommon_sample/wards/ScannedWardTracker.kt
@@ -6,32 +6,40 @@ import kotlinx.coroutines.flow.StateFlow
 
 object ScannedWardTracker {
 
-    data class WardEntry(val name: String, val maxRssi: Int)
+    enum class Source { SCAN, BUNDLE_ONLY }
+
+    data class WardEntry(
+        val name: String,
+        val maxRssi: Int?,
+        val source: Source,
+        val matchedLevel: String?,
+    ) {
+        val isScanned: Boolean get() = source == Source.SCAN
+        val isMatched: Boolean get() = matchedLevel != null
+    }
 
     private val maxRssiByName = linkedMapOf<String, Int>()
+    private var bundleWards: BundleWardMap? = null
 
     private val _entries = MutableStateFlow<List<WardEntry>>(emptyList())
     val entries: StateFlow<List<WardEntry>> = _entries
 
-    private val _checkedNames = MutableStateFlow<Set<String>>(emptySet())
-    val checkedNames: StateFlow<Set<String>> = _checkedNames
+    private val _bundleSectorId = MutableStateFlow<Int?>(null)
+    val bundleSectorId: StateFlow<Int?> = _bundleSectorId
 
     @Synchronized
     fun reset() {
         maxRssiByName.clear()
+        bundleWards = null
+        _bundleSectorId.value = null
         _entries.value = emptyList()
-        _checkedNames.value = emptySet()
     }
 
     @Synchronized
-    fun toggleChecked(name: String) {
-        val current = _checkedNames.value
-        _checkedNames.value = if (name in current) current - name else current + name
-    }
-
-    @Synchronized
-    fun resetChecks() {
-        _checkedNames.value = emptySet()
+    fun clearBundle() {
+        bundleWards = null
+        _bundleSectorId.value = null
+        publish()
     }
 
     @Synchronized
@@ -48,23 +56,58 @@ object ScannedWardTracker {
         if (changed) publish()
     }
 
-    private fun publish() {
-        _entries.value = maxRssiByName.entries
-            .map { WardEntry(it.key, it.value) }
-            .sortedWith(compareBy(wardNameComparator) { it.name })
+    @Synchronized
+    fun applyBundle(bundle: BundleWardMap) {
+        bundleWards = bundle
+        _bundleSectorId.value = bundle.sectorId
+        publish()
     }
 
-    // Ward name format: TJ-00CB-0001012C-0000 → sort by the 3rd segment (index 2) as hex.
-    // Names that don't match fall back to whole-string compare and sink to the end.
-    private val wardNameComparator = Comparator<String> { a, b ->
-        val ka = hexKeyOf(a)
-        val kb = hexKeyOf(b)
+    private fun publish() {
+        val bundle = bundleWards
+        val scanEntries = maxRssiByName.map { (name, rssi) ->
+            WardEntry(
+                name = name,
+                maxRssi = rssi,
+                source = Source.SCAN,
+                matchedLevel = bundle?.nameToLevelLabel?.get(name),
+            )
+        }
+        val bundleOnlyEntries = bundle?.let { b ->
+            b.nameToLevelLabel.entries
+                .filter { it.key !in maxRssiByName }
+                .map { (name, level) ->
+                    WardEntry(
+                        name = name,
+                        maxRssi = null,
+                        source = Source.BUNDLE_ONLY,
+                        matchedLevel = level,
+                    )
+                }
+        }.orEmpty()
+
+        _entries.value = (scanEntries + bundleOnlyEntries)
+            .sortedWith(entryOrder)
+    }
+
+    private val entryOrder = Comparator<WardEntry> { a, b ->
+        val groupA = groupRank(a)
+        val groupB = groupRank(b)
+        if (groupA != groupB) return@Comparator groupA - groupB
+        val ka = hexKeyOf(a.name)
+        val kb = hexKeyOf(b.name)
         when {
             ka != null && kb != null -> ka.compareTo(kb)
             ka != null -> -1
             kb != null -> 1
-            else -> a.compareTo(b, ignoreCase = true)
+            else -> a.name.compareTo(b.name, ignoreCase = true)
         }
+    }
+
+    private fun groupRank(e: WardEntry): Int = when {
+        e.source == Source.SCAN && e.isMatched -> 0
+        e.source == Source.SCAN -> 1
+        else -> 2
     }
 
     private fun hexKeyOf(name: String): Long? {

--- a/app/src/main/java/com/tjlabs/tjlabscommon_sample/wards/ScannedWardsActivity.kt
+++ b/app/src/main/java/com/tjlabs/tjlabscommon_sample/wards/ScannedWardsActivity.kt
@@ -1,5 +1,7 @@
 package com.tjlabs.tjlabscommon_sample.wards
 
+import android.app.AlertDialog
+import android.app.ProgressDialog
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -9,49 +11,87 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
+import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.tjlabs.tjlabscommon_sample.R
+import com.tjlabs.tjlabscommon_sample.preview.SessionMeta
+import com.tjlabs.tjlabscommon_sample.preview.TelemetryFileReader
+import com.tjlabs.tjlabscommon_sample.preview.TestSet
+import com.tjlabs.tjlabscommon_sample.preview.TestSetRepository
+import com.tjlabs.tjlabscommon_sdk_android.rfd.ReceivedForce
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class ScannedWardsActivity : AppCompatActivity() {
 
-    private lateinit var tvCount: TextView
-    private lateinit var tvChecked: TextView
+    companion object {
+        const val EXTRA_SECTOR_ID = "extra_sector_id"
+        const val EXTRA_SECTOR_DISPLAY = "extra_sector_display"
+    }
+
     private lateinit var tvEmpty: TextView
+    private lateinit var chipMatched: TextView
+    private lateinit var chipScanOnly: TextView
+    private lateinit var chipBundleOnly: TextView
     private lateinit var etSearch: EditText
     private lateinit var btnReset: Button
-    private lateinit var btnUncheck: Button
+    private lateinit var btnCompare: Button
+    private lateinit var btnLoadFile: Button
     private lateinit var rvWards: RecyclerView
-    private val adapter = ScannedWardAdapter { name -> ScannedWardTracker.toggleChecked(name) }
+    private lateinit var cardLevelSummary: View
+    private lateinit var tvLevelSummary: TextView
+    private val adapter = ScannedWardAdapter()
 
+    private enum class GroupFilter { MATCHED, SCAN_ONLY, BUNDLE_ONLY }
     private val queryFlow = MutableStateFlow("")
+    private val filterFlow = MutableStateFlow<GroupFilter?>(null)
+    private var sectorId: Int = -1
+    private var sectorDisplay: String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_scanned_wards)
 
+        sectorId = intent.getIntExtra(EXTRA_SECTOR_ID, -1)
+        sectorDisplay = intent.getStringExtra(EXTRA_SECTOR_DISPLAY).orEmpty()
+
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         title = "Scanned Wards"
 
-        tvCount = findViewById(R.id.tvWardsCount)
-        tvChecked = findViewById(R.id.tvWardsChecked)
         tvEmpty = findViewById(R.id.tvWardsEmpty)
+        chipMatched = findViewById(R.id.chipMatched)
+        chipScanOnly = findViewById(R.id.chipScanOnly)
+        chipBundleOnly = findViewById(R.id.chipBundleOnly)
         etSearch = findViewById(R.id.etWardSearch)
         btnReset = findViewById(R.id.btnWardsReset)
-        btnUncheck = findViewById(R.id.btnWardsUncheck)
+        btnCompare = findViewById(R.id.btnWardsCompare)
+        btnLoadFile = findViewById(R.id.btnWardsLoadFile)
         rvWards = findViewById(R.id.rvScannedWards)
+        cardLevelSummary = findViewById(R.id.cardLevelSummary)
+        tvLevelSummary = findViewById(R.id.tvLevelSummary)
 
         rvWards.layoutManager = LinearLayoutManager(this)
         rvWards.adapter = adapter
 
         btnReset.setOnClickListener { ScannedWardTracker.reset() }
-        btnUncheck.setOnClickListener { ScannedWardTracker.resetChecks() }
+        btnCompare.setOnClickListener { compareWithBundle() }
+        btnLoadFile.setOnClickListener { showLoadFromFileDialog() }
+
+        chipMatched.setOnClickListener { toggleFilter(GroupFilter.MATCHED) }
+        chipScanOnly.setOnClickListener { toggleFilter(GroupFilter.SCAN_ONLY) }
+        chipBundleOnly.setOnClickListener { toggleFilter(GroupFilter.BUNDLE_ONLY) }
 
         etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
@@ -65,9 +105,10 @@ class ScannedWardsActivity : AppCompatActivity() {
             combine(
                 ScannedWardTracker.entries,
                 queryFlow,
-                ScannedWardTracker.checkedNames,
-            ) { list, query, checked ->
-                RenderState(list, query, checked)
+                ScannedWardTracker.bundleSectorId,
+                filterFlow,
+            ) { list, query, bundleSector, filter ->
+                RenderState(list, query, bundleSector, filter)
             }.collect { state -> render(state) }
         }
     }
@@ -77,38 +118,83 @@ class ScannedWardsActivity : AppCompatActivity() {
         return true
     }
 
+    private fun toggleFilter(target: GroupFilter) {
+        filterFlow.value = if (filterFlow.value == target) null else target
+    }
+
+    private fun buildRows(
+        entries: List<ScannedWardTracker.WardEntry>,
+        showSections: Boolean,
+    ): List<Row> {
+        if (!showSections) {
+            return entries.mapIndexed { i, e -> Row.Entry(i + 1, e) }
+        }
+        val byLevel = LinkedHashMap<String, MutableList<ScannedWardTracker.WardEntry>>()
+        val unmatched = mutableListOf<ScannedWardTracker.WardEntry>()
+        for (e in entries) {
+            val level = e.matchedLevel
+            if (level != null) byLevel.getOrPut(level) { mutableListOf() } += e
+            else unmatched += e
+        }
+        val rows = mutableListOf<Row>()
+        for ((level, items) in byLevel) {
+            rows += Row.Header(level, items.size, SectionKind.LEVEL)
+            items.forEachIndexed { i, e -> rows += Row.Entry(i + 1, e) }
+        }
+        if (unmatched.isNotEmpty()) {
+            rows += Row.Header("Unmatched (scan)", unmatched.size, SectionKind.UNMATCHED)
+            unmatched.forEachIndexed { i, e -> rows += Row.Entry(i + 1, e) }
+        }
+        return rows
+    }
+
+    enum class SectionKind { LEVEL, UNMATCHED }
+
+    sealed class Row {
+        data class Header(val title: String, val count: Int, val kind: SectionKind) : Row()
+        data class Entry(val indexInSection: Int, val entry: ScannedWardTracker.WardEntry) : Row()
+    }
+
     private data class RenderState(
         val entries: List<ScannedWardTracker.WardEntry>,
         val query: String,
-        val checked: Set<String>,
+        val bundleSectorId: Int?,
+        val filter: GroupFilter?,
     )
 
     private fun render(state: RenderState) {
-        val total = state.entries.size
+        val matchedCount = state.entries.count { it.isScanned && it.isMatched }
+        val scanOnlyCount = state.entries.count { it.isScanned && !it.isMatched }
+        val bundleOnlyCount = state.entries.count { it.source == ScannedWardTracker.Source.BUNDLE_ONLY }
+
+        chipMatched.text = "Match $matchedCount"
+        chipScanOnly.text = "Scan $scanOnlyCount"
+        chipBundleOnly.text = "Bundle $bundleOnlyCount"
+        chipMatched.isSelected = state.filter == GroupFilter.MATCHED
+        chipScanOnly.isSelected = state.filter == GroupFilter.SCAN_ONLY
+        chipBundleOnly.isSelected = state.filter == GroupFilter.BUNDLE_ONLY
+
+        renderLevelSummary(state.entries, state.bundleSectorId)
+
+        val byGroup = state.entries.filter { entry ->
+            when (state.filter) {
+                GroupFilter.MATCHED -> entry.isScanned && entry.isMatched
+                GroupFilter.SCAN_ONLY -> entry.isScanned && !entry.isMatched
+                GroupFilter.BUNDLE_ONLY -> entry.source == ScannedWardTracker.Source.BUNDLE_ONLY
+                null -> true
+            }
+        }
         val filtered = if (state.query.isBlank()) {
-            state.entries
+            byGroup
         } else {
             val q = state.query.trim().lowercase()
-            state.entries.filter { it.name.lowercase().contains(q) }
+            byGroup.filter { it.name.lowercase().contains(q) }
         }
 
-        tvCount.text = "Total: $total (showing ${filtered.size})"
+        val rows = buildRows(filtered, showSections = state.bundleSectorId != null)
+        adapter.submit(rows)
 
-        val checkedIndices = state.entries
-            .mapIndexedNotNull { index, entry ->
-                if (entry.name in state.checked) index + 1 else null
-            }
-        tvChecked.text = if (checkedIndices.isEmpty()) {
-            "Checked: 0"
-        } else {
-            "Checked: ${checkedIndices.size} → " +
-                checkedIndices.joinToString(", ") { "#$it" }
-        }
-
-        val nameToFullIndex = HashMap<String, Int>(state.entries.size)
-        state.entries.forEachIndexed { i, e -> nameToFullIndex[e.name] = i + 1 }
-        adapter.submit(filtered, state.checked, nameToFullIndex)
-
+        val total = state.entries.size
         val showEmpty = total == 0 || filtered.isEmpty()
         tvEmpty.visibility = if (showEmpty) View.VISIBLE else View.GONE
         tvEmpty.text = when {
@@ -118,57 +204,312 @@ class ScannedWardsActivity : AppCompatActivity() {
         }
         rvWards.visibility = if (showEmpty) View.GONE else View.VISIBLE
     }
+
+    private fun renderLevelSummary(
+        entries: List<ScannedWardTracker.WardEntry>,
+        bundleSectorId: Int?,
+    ) {
+        if (bundleSectorId == null) {
+            cardLevelSummary.visibility = View.GONE
+            return
+        }
+        val byLevel = LinkedHashMap<String, MutableList<ScannedWardTracker.WardEntry>>()
+        for (e in entries) {
+            val level = e.matchedLevel ?: continue
+            byLevel.getOrPut(level) { mutableListOf() } += e
+        }
+        if (byLevel.isEmpty()) {
+            cardLevelSummary.visibility = View.GONE
+            return
+        }
+        cardLevelSummary.visibility = View.VISIBLE
+        tvLevelSummary.text = byLevel.entries.joinToString(separator = "  ") { (level, items) ->
+            val matched = items.count { it.isScanned }
+            "$level(${matched}/${items.size})"
+        }
+    }
+
+    private fun compareWithBundle() {
+        if (sectorId < 0) {
+            Toast.makeText(this, "Sector 미설정 — MainActivity에서 선택 후 다시 열어주세요.", Toast.LENGTH_LONG).show()
+            return
+        }
+        val progress = ProgressDialog(this).apply {
+            setMessage("Bundle 로드 중… (sector $sectorId)")
+            setCancelable(false)
+            show()
+        }
+        BundleService.load(application, sectorId) { result ->
+            runOnUiThread {
+                progress.dismiss()
+                result.onSuccess { bundle ->
+                    ScannedWardTracker.applyBundle(bundle)
+                    Toast.makeText(
+                        this,
+                        "Bundle: ${bundle.nameToLevelLabel.size} wards / ${bundle.levelCount} levels",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }.onFailure { err ->
+                    Toast.makeText(this, "Bundle 로드 실패: ${err.message}", Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+
+    private fun showLoadFromFileDialog() {
+        lifecycleScope.launch {
+            val sets = withContext(Dispatchers.IO) { TestSetRepository.list(application) }
+                .filter { it.hasType("rfd") }
+            if (sets.isEmpty()) {
+                Toast.makeText(this@ScannedWardsActivity, "저장된 RFD 파일이 없습니다.", Toast.LENGTH_LONG).show()
+                return@launch
+            }
+            showMultiSelectDialog(groupDialogEntries(sets))
+        }
+    }
+
+    private data class FileRow(val primary: String, val secondary: String, val set: TestSet)
+    private data class FileGroup(val title: String, val rows: List<FileRow>)
+
+    private fun groupDialogEntries(sets: List<TestSet>): List<FileGroup> {
+        val ts = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        val currentSector = mutableListOf<FileRow>()
+        val otherSector = mutableListOf<FileRow>()
+        val noMeta = mutableListOf<FileRow>()
+
+        for (set in sets) {
+            val when_ = set.timestampMillis()
+                .takeIf { it > 0 }?.let { ts.format(Date(it)) } ?: set.serviceStartTime
+            val size = "${set.totalBytes() / 1024} KB"
+            val meta = set.meta
+            when {
+                meta == null -> noMeta += FileRow(
+                    primary = "${set.userId} · $when_",
+                    secondary = "no metadata · $size",
+                    set = set
+                )
+                sectorId >= 0 && meta.sectorId == sectorId -> currentSector += FileRow(
+                    primary = "${meta.userId} · $when_",
+                    secondary = "${describeSector(meta)} · $size",
+                    set = set
+                )
+                else -> otherSector += FileRow(
+                    primary = "${meta.userId} · $when_",
+                    secondary = "${describeSector(meta)} · $size",
+                    set = set
+                )
+            }
+        }
+        val result = mutableListOf<FileGroup>()
+        if (currentSector.isNotEmpty()) result += FileGroup("Current sector", currentSector)
+        if (otherSector.isNotEmpty()) result += FileGroup("Other sector", otherSector)
+        if (noMeta.isNotEmpty()) result += FileGroup("No metadata", noMeta)
+        return result
+    }
+
+    private fun describeSector(meta: SessionMeta): String = when {
+        meta.sectorDisplay.isNotBlank() -> "sector ${meta.sectorDisplay}"
+        meta.sectorId >= 0 -> "sector ${meta.sectorId}"
+        else -> "sector ?"
+    }
+
+    private fun showMultiSelectDialog(groups: List<FileGroup>) {
+        val inflater = LayoutInflater.from(this)
+        val root = inflater.inflate(R.layout.dialog_load_wards, null) as LinearLayout
+        val summary = root.findViewById<TextView>(R.id.tvDialogSummary)
+        val btnSelectAll = root.findViewById<Button>(R.id.btnDialogSelectAll)
+        val btnClear = root.findViewById<Button>(R.id.btnDialogClear)
+        val listContainer = root.findViewById<LinearLayout>(R.id.dialogListContainer)
+
+        val selected = LinkedHashSet<TestSet>()
+        val rowViews = mutableListOf<Pair<TestSet, CheckBox>>()
+
+        fun refreshSummary() {
+            val totalKB = selected.sumOf { it.totalBytes() } / 1024
+            summary.text = if (selected.isEmpty()) "0 selected" else "${selected.size} selected · $totalKB KB"
+        }
+
+        fun addRow(row: FileRow) {
+            val view = inflater.inflate(R.layout.item_load_wards_entry, listContainer, false)
+            val cb = view.findViewById<CheckBox>(R.id.cbSelect)
+            view.findViewById<TextView>(R.id.tvPrimary).text = row.primary
+            view.findViewById<TextView>(R.id.tvSecondary).text = row.secondary
+            view.setOnClickListener {
+                cb.isChecked = !cb.isChecked
+            }
+            cb.setOnCheckedChangeListener { _, checked ->
+                if (checked) selected += row.set else selected -= row.set
+                refreshSummary()
+            }
+            listContainer.addView(view)
+            rowViews += row.set to cb
+        }
+
+        for (group in groups) {
+            val header = inflater.inflate(R.layout.item_load_wards_header, listContainer, false) as TextView
+            header.text = group.title
+            listContainer.addView(header)
+            for (row in group.rows) addRow(row)
+        }
+
+        btnSelectAll.setOnClickListener {
+            rowViews.forEach { it.second.isChecked = true }
+        }
+        btnClear.setOnClickListener {
+            rowViews.forEach { it.second.isChecked = false }
+        }
+
+        refreshSummary()
+
+        val dialog = AlertDialog.Builder(this)
+            .setTitle("Load RFD sessions")
+            .setView(root)
+            .setPositiveButton("Load", null)
+            .setNegativeButton("Cancel", null)
+            .create()
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                if (selected.isEmpty()) {
+                    Toast.makeText(this, "선택된 파일이 없습니다.", Toast.LENGTH_SHORT).show()
+                    return@setOnClickListener
+                }
+                dialog.dismiss()
+                replayIntoTracker(selected.toList())
+            }
+        }
+        dialog.show()
+    }
+
+    private fun replayIntoTracker(sets: List<TestSet>) {
+        val progress = ProgressDialog(this).apply {
+            setMessage("파일 로드 중…")
+            setCancelable(false)
+            show()
+        }
+        lifecycleScope.launch {
+            var totalSamples = 0
+            for (set in sets) {
+                val samples = withContext(Dispatchers.IO) {
+                    TelemetryFileReader.readRfd(application, set.userId, set.serviceStartTime)
+                }
+                if (samples.isEmpty()) continue
+                withContext(Dispatchers.Default) {
+                    for (s in samples) {
+                        ScannedWardTracker.record(
+                            ReceivedForce(mobile_time = s.mobileTime, rfs = s.rfs)
+                        )
+                    }
+                }
+                totalSamples += samples.size
+            }
+            progress.dismiss()
+            Toast.makeText(
+                this@ScannedWardsActivity,
+                "Loaded ${sets.size} session(s) · $totalSamples RFD samples",
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
 }
 
-private class ScannedWardAdapter(
-    private val onToggle: (String) -> Unit,
-) : RecyclerView.Adapter<ScannedWardAdapter.WardViewHolder>() {
+private class ScannedWardAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    private val items = mutableListOf<ScannedWardTracker.WardEntry>()
-    private var checked: Set<String> = emptySet()
-    private var indexLookup: Map<String, Int> = emptyMap()
+    companion object {
+        private const val TYPE_HEADER = 0
+        private const val TYPE_ENTRY = 1
+    }
 
-    fun submit(
-        newItems: List<ScannedWardTracker.WardEntry>,
-        newChecked: Set<String>,
-        newIndexLookup: Map<String, Int>,
-    ) {
-        items.clear()
-        items.addAll(newItems)
-        checked = newChecked
-        indexLookup = newIndexLookup
+    private val rows = mutableListOf<ScannedWardsActivity.Row>()
+
+    fun submit(newRows: List<ScannedWardsActivity.Row>) {
+        rows.clear()
+        rows.addAll(newRows)
         notifyDataSetChanged()
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): WardViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.item_scanned_ward, parent, false)
-        return WardViewHolder(view, onToggle)
+    override fun getItemViewType(position: Int): Int = when (rows[position]) {
+        is ScannedWardsActivity.Row.Header -> TYPE_HEADER
+        is ScannedWardsActivity.Row.Entry -> TYPE_ENTRY
     }
 
-    override fun onBindViewHolder(holder: WardViewHolder, position: Int) {
-        val entry = items[position]
-        val fullIndex = indexLookup[entry.name] ?: (position + 1)
-        holder.bind(fullIndex, entry, entry.name in checked)
+    override fun getItemCount(): Int = rows.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            TYPE_HEADER -> HeaderViewHolder(
+                inflater.inflate(R.layout.item_ward_section, parent, false)
+            )
+            else -> WardViewHolder(
+                inflater.inflate(R.layout.item_scanned_ward, parent, false)
+            )
+        }
     }
 
-    override fun getItemCount(): Int = items.size
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (val row = rows[position]) {
+            is ScannedWardsActivity.Row.Header -> (holder as HeaderViewHolder).bind(row)
+            is ScannedWardsActivity.Row.Entry -> (holder as WardViewHolder)
+                .bind(row.indexInSection, row.entry)
+        }
+    }
 
-    class WardViewHolder(
-        itemView: View,
-        private val onToggle: (String) -> Unit,
-    ) : RecyclerView.ViewHolder(itemView) {
-        private val cbChecked: CheckBox = itemView.findViewById(R.id.cbWardChecked)
+    class HeaderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val dot: View = itemView.findViewById(R.id.vSectionDot)
+        private val title: TextView = itemView.findViewById(R.id.tvSectionTitle)
+        private val count: TextView = itemView.findViewById(R.id.tvSectionCount)
+
+        fun bind(row: ScannedWardsActivity.Row.Header) {
+            title.text = row.title
+            count.text = "${row.count}"
+            val ctx = itemView.context
+            val bg = when (row.kind) {
+                ScannedWardsActivity.SectionKind.UNMATCHED ->
+                    ContextCompat.getColor(ctx, R.color.ward_scan_only_text)
+                else -> ContextCompat.getColor(ctx, R.color.brand_primary)
+            }
+            val shape = android.graphics.drawable.GradientDrawable().apply {
+                shape = android.graphics.drawable.GradientDrawable.OVAL
+                setColor(bg)
+            }
+            dot.background = shape
+        }
+    }
+
+    class WardViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val root: View = itemView.findViewById(R.id.wardItemRoot)
         private val tvIndex: TextView = itemView.findViewById(R.id.tvWardIndex)
         private val tvName: TextView = itemView.findViewById(R.id.tvWardName)
         private val tvRssi: TextView = itemView.findViewById(R.id.tvWardRssi)
 
-        fun bind(index: Int, entry: ScannedWardTracker.WardEntry, isChecked: Boolean) {
-            cbChecked.isChecked = isChecked
+        fun bind(index: Int, entry: ScannedWardTracker.WardEntry) {
+            val ctx = itemView.context
             tvIndex.text = "${index}."
             tvName.text = entry.name
-            tvRssi.text = "max RSSI: ${entry.maxRssi}"
-            itemView.setOnClickListener { onToggle(entry.name) }
+
+            when {
+                entry.source == ScannedWardTracker.Source.BUNDLE_ONLY -> {
+                    root.setBackgroundColor(ContextCompat.getColor(ctx, R.color.ward_bundle_only_bg))
+                    val txt = ContextCompat.getColor(ctx, R.color.ward_bundle_only_text)
+                    tvName.setTextColor(txt)
+                    tvRssi.setTextColor(txt)
+                    tvRssi.text = "(not scanned)"
+                }
+                entry.isMatched -> {
+                    root.setBackgroundColor(ContextCompat.getColor(ctx, R.color.ward_matched_bg))
+                    val txt = ContextCompat.getColor(ctx, R.color.ward_matched_text)
+                    tvName.setTextColor(txt)
+                    tvRssi.setTextColor(txt)
+                    tvRssi.text = "max RSSI: ${entry.maxRssi ?: '-'}"
+                }
+                else -> {
+                    root.setBackgroundColor(ContextCompat.getColor(ctx, R.color.ward_scan_only_bg))
+                    val txt = ContextCompat.getColor(ctx, R.color.ward_scan_only_text)
+                    tvName.setTextColor(txt)
+                    tvRssi.setTextColor(txt)
+                    tvRssi.text = "max RSSI: ${entry.maxRssi ?: '-'}"
+                }
+            }
         }
     }
 }

--- a/app/src/main/res/drawable/legend_chip_bg.xml
+++ b/app/src/main/res/drawable/legend_chip_bg.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="16dp" />
+            <stroke android:width="1.5dp" android:color="@color/brand_primary" />
+            <solid android:color="@color/surface_selected" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="16dp" />
+            <stroke android:width="1dp" android:color="@color/divider" />
+            <solid android:color="@color/surface_card" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/legend_dot_bundle_only.xml
+++ b/app/src/main/res/drawable/legend_dot_bundle_only.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size android:width="10dp" android:height="10dp" />
+    <solid android:color="@color/ward_bundle_only_text" />
+</shape>

--- a/app/src/main/res/drawable/legend_dot_matched.xml
+++ b/app/src/main/res/drawable/legend_dot_matched.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size android:width="10dp" android:height="10dp" />
+    <solid android:color="@color/ward_matched_text" />
+</shape>

--- a/app/src/main/res/drawable/legend_dot_scan_only.xml
+++ b/app/src/main/res/drawable/legend_dot_scan_only.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size android:width="10dp" android:height="10dp" />
+    <solid android:color="@color/ward_scan_only_text" />
+</shape>

--- a/app/src/main/res/layout/activity_scanned_wards.xml
+++ b/app/src/main/res/layout/activity_scanned_wards.xml
@@ -29,50 +29,78 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:baselineAligned="false">
 
                 <TextView
-                    android:id="@+id/tvWardsCount"
+                    android:id="@+id/chipMatched"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="Total: 0 (showing 0)"
-                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-                    android:textColor="@color/text_primary"
-                    android:textStyle="bold" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnWardsReset"
-                    android:layout_width="wrap_content"
-                    android:layout_marginStart="@dimen/space_s"
-                    style="@style/AppButton.Danger"
-                    android:text="Reset" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/space_xs"
-                android:gravity="top"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:id="@+id/tvWardsChecked"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Checked: 0"
-                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+                    android:background="@drawable/legend_chip_bg"
+                    android:clickable="true"
+                    android:drawableStart="@drawable/legend_dot_matched"
+                    android:drawablePadding="@dimen/space_xs"
+                    android:ellipsize="none"
+                    android:focusable="true"
+                    android:gravity="center"
+                    android:maxLines="1"
+                    android:paddingHorizontal="@dimen/space_s"
+                    android:paddingVertical="@dimen/space_s"
+                    android:text="Match 0"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
                     android:textColor="@color/text_primary" />
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnWardsUncheck"
-                    android:layout_width="wrap_content"
-                    android:layout_marginStart="@dimen/space_s"
-                    style="@style/AppButton.Outlined"
-                    android:text="Uncheck" />
+                <TextView
+                    android:id="@+id/chipScanOnly"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_xs"
+                    android:layout_weight="1"
+                    android:background="@drawable/legend_chip_bg"
+                    android:clickable="true"
+                    android:drawableStart="@drawable/legend_dot_scan_only"
+                    android:drawablePadding="@dimen/space_xs"
+                    android:ellipsize="none"
+                    android:focusable="true"
+                    android:gravity="center"
+                    android:maxLines="1"
+                    android:paddingHorizontal="@dimen/space_s"
+                    android:paddingVertical="@dimen/space_s"
+                    android:text="Scan 0"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+                    android:textColor="@color/text_primary" />
+
+                <TextView
+                    android:id="@+id/chipBundleOnly"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_xs"
+                    android:layout_weight="1"
+                    android:background="@drawable/legend_chip_bg"
+                    android:clickable="true"
+                    android:drawableStart="@drawable/legend_dot_bundle_only"
+                    android:drawablePadding="@dimen/space_xs"
+                    android:ellipsize="none"
+                    android:focusable="true"
+                    android:gravity="center"
+                    android:maxLines="1"
+                    android:paddingHorizontal="@dimen/space_s"
+                    android:paddingVertical="@dimen/space_s"
+                    android:text="Bundle 0"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+                    android:textColor="@color/text_primary" />
             </LinearLayout>
+
+            <TextView
+                android:id="@+id/tvWardsStatus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/space_s"
+                android:text=""
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+                android:textColor="@color/text_secondary"
+                android:visibility="gone" />
 
             <EditText
                 android:id="@+id/etWardSearch"
@@ -85,7 +113,55 @@
                 android:maxLines="1"
                 android:textColor="@color/text_primary"
                 android:textColorHint="@color/text_secondary" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/space_s"
+                android:orientation="horizontal"
+                android:baselineAligned="false">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnWardsCompare"
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    style="@style/AppButton.Primary"
+                    android:text="Compare" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnWardsLoadFile"
+                    android:layout_width="0dp"
+                    android:layout_marginStart="@dimen/space_s"
+                    android:layout_weight="1"
+                    style="@style/AppButton.Outlined"
+                    android:text="Load" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnWardsReset"
+                    android:layout_width="0dp"
+                    android:layout_marginStart="@dimen/space_s"
+                    android:layout_weight="1"
+                    style="@style/AppButton.Danger"
+                    android:text="Reset" />
+            </LinearLayout>
         </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cardLevelSummary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        style="@style/AppCard">
+
+        <TextView
+            android:id="@+id/tvLevelSummary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lineSpacingExtra="2dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+            android:textColor="@color/text_primary"
+            android:textSize="11sp" />
     </com.google.android.material.card.MaterialCardView>
 
     <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/dialog_load_wards.xml
+++ b/app/src/main/res/layout/dialog_load_wards.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/surface_card"
+    android:orientation="vertical"
+    android:paddingHorizontal="@dimen/space_l"
+    android:paddingTop="@dimen/space_l"
+    android:paddingBottom="@dimen/space_s">
+
+    <TextView
+        android:id="@+id/tvDialogSummary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="0 selected"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+        android:textColor="@color/text_secondary" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/space_s"
+        android:baselineAligned="false"
+        android:orientation="horizontal">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnDialogSelectAll"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            style="@style/AppButton.Outlined"
+            android:text="Select all" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnDialogClear"
+            android:layout_width="0dp"
+            android:layout_marginStart="@dimen/space_s"
+            android:layout_weight="1"
+            style="@style/AppButton.Outlined"
+            android:text="Clear" />
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="@dimen/space_m"
+        android:background="@color/divider" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="@dimen/space_s"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:id="@+id/dialogListContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_load_wards_entry.xml
+++ b/app/src/main/res/layout/item_load_wards_entry.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/rowRoot"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingHorizontal="@dimen/space_xs"
+    android:paddingVertical="@dimen/space_s">
+
+    <CheckBox
+        android:id="@+id/cbSelect"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="false"
+        android:focusable="false" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/space_s"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tvPrimary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/tvSecondary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+            android:textColor="@color/text_secondary" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_load_wards_header.xml
+++ b/app/src/main/res/layout/item_load_wards_header.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tvSectionTitle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/space_s"
+    android:paddingHorizontal="@dimen/space_xs"
+    android:paddingVertical="@dimen/space_xs"
+    android:letterSpacing="0.08"
+    android:textAllCaps="true"
+    android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+    android:textColor="@color/text_section"
+    android:textStyle="bold" />

--- a/app/src/main/res/layout/item_scanned_ward.xml
+++ b/app/src/main/res/layout/item_scanned_ward.xml
@@ -1,61 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/wardItemRoot"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:paddingHorizontal="@dimen/space_xs"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingHorizontal="@dimen/space_s"
     android:paddingVertical="@dimen/space_s">
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <TextView
+        android:id="@+id/tvWardIndex"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_vertical">
+        android:layout_marginEnd="@dimen/space_s"
+        android:minWidth="32dp"
+        android:text="1."
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+        android:textColor="@color/text_secondary" />
 
-        <CheckBox
-            android:id="@+id/cbWardChecked"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/space_xs"
-            android:clickable="false"
-            android:focusable="false" />
+    <TextView
+        android:id="@+id/tvWardName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="Name"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
+        android:textColor="@color/text_primary"
+        android:textStyle="bold" />
 
-        <TextView
-            android:id="@+id/tvWardIndex"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/space_s"
-            android:minWidth="32dp"
-            android:text="1."
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-            android:textColor="@color/text_secondary" />
-
-        <TextView
-            android:id="@+id/tvWardName"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:ellipsize="middle"
-            android:maxLines="1"
-            android:text="Name"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
-            android:textColor="@color/text_primary"
-            android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/tvWardRssi"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/space_s"
-            android:text="max RSSI: -80"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-            android:textColor="@color/text_primary" />
-    </LinearLayout>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginTop="@dimen/space_s"
-        android:background="@color/divider" />
+    <TextView
+        android:id="@+id/tvWardRssi"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/space_s"
+        android:text="max RSSI: -80"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+        android:textColor="@color/text_primary" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_ward_section.xml
+++ b/app/src/main/res/layout/item_ward_section.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingHorizontal="@dimen/space_s"
+    android:paddingTop="@dimen/space_m"
+    android:paddingBottom="@dimen/space_xs">
+
+    <View
+        android:id="@+id/vSectionDot"
+        android:layout_width="8dp"
+        android:layout_height="8dp"
+        android:layout_marginEnd="@dimen/space_s" />
+
+    <TextView
+        android:id="@+id/tvSectionTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:letterSpacing="0.05"
+        android:textAllCaps="true"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+        android:textColor="@color/text_section"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/tvSectionCount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/space_s"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+        android:textColor="@color/text_secondary" />
+
+</LinearLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -16,6 +16,13 @@
 
     <color name="divider">#334155</color>
 
+    <color name="ward_matched_bg">#14532D</color>
+    <color name="ward_matched_text">#BBF7D0</color>
+    <color name="ward_scan_only_bg">#78350F</color>
+    <color name="ward_scan_only_text">#FDE68A</color>
+    <color name="ward_bundle_only_bg">#1F2937</color>
+    <color name="ward_bundle_only_text">#9CA3AF</color>
+
     <!-- Disabled button states need darker bg/stroke and dimmer text on dark surfaces -->
     <color name="button_disabled_bg">#334155</color>
     <color name="button_disabled_stroke">#334155</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,6 +20,13 @@
 
     <color name="divider">#E5E7EB</color>
 
+    <color name="ward_matched_bg">#DCFCE7</color>
+    <color name="ward_matched_text">#166534</color>
+    <color name="ward_scan_only_bg">#FEF3C7</color>
+    <color name="ward_scan_only_text">#92400E</color>
+    <color name="ward_bundle_only_bg">#F3F4F6</color>
+    <color name="ward_bundle_only_text">#6B7280</color>
+
     <color name="button_disabled_bg">#D1D5DB</color>
     <color name="button_disabled_stroke">#D1D5DB</color>
     <color name="button_disabled_text">#9CA3AF</color>


### PR DESCRIPTION
## Summary
- Adds `TJLabsResource-sdk-android` dependency and a `BundleService` wrapper to fetch the selected sector's wards grouped by level.
- **Compare** button loads the bundle and colors scanned wards: matched (green) / scan-only (yellow) / bundle-only (gray).
- Legend chips (Match/Scan/Bundle) double as filters.
- Ward list grouped by level with section headers; unmatched scans get their own section.
- Compact per-level summary above the list, e.g. `B1(0/12)  B2(8/10)`.
- Load-from-file dialog supports multi-select, grouped by current-sector / other-sector / no-metadata.

## Test plan
- [ ] Auth + sector selected → open Wards, Compare loads bundle, levels/counts look right
- [ ] Colors and section headers render for each state (matched / scan-only / bundle-only)
- [ ] Legend chips filter the list
- [ ] Load-from-file dialog: multi-select loads all picked sessions; no-meta and other-sector sessions surface in their sections
- [ ] Reset clears both scans and bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)